### PR TITLE
Allow context type override

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,14 +18,14 @@ export function useLongPress<Target = Element, Context = unknown>(
   options?: LongPressOptions<Target>
 ): CallableContextResult<EmptyObject, Context>;
 export function useLongPress<
+  Context = unknown,
   Target = Element,
-  Callback extends LongPressCallback<Target, any> = LongPressCallback<Target>,
-  Context = unknown
+  Callback extends LongPressCallback<Target, Context> = LongPressCallback<Target, Context>
 >(callback: Callback, options?: LongPressOptions<Target>): CallableContextResult<LongPressResult<Target>, Context>;
 export function useLongPress<
+  Context = unknown,
   Target = Element,
-  Callback extends LongPressCallback<Target, any> = LongPressCallback<Target>,
-  Context = unknown
+  Callback extends LongPressCallback<Target, Context> = LongPressCallback<Target, Context>
 >(
   callback: Callback | null,
   options?: LongPressOptions<Target>
@@ -61,9 +61,9 @@ export function useLongPress<
  * </ul>
  */
 export function useLongPress<
+  Context extends unknown = undefined,
   Target extends Element = Element,
-  Callback extends LongPressCallback<Target> = LongPressCallback<Target>,
-  Context extends unknown = undefined
+  Callback extends LongPressCallback<Target, Context> = LongPressCallback<Target, Context>
 >(
   callback: Callback | null,
   {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,12 +19,12 @@ export function useLongPress<Target = Element, Context = unknown>(
 ): CallableContextResult<EmptyObject, Context>;
 export function useLongPress<
   Target = Element,
-  Callback extends LongPressCallback<Target> = LongPressCallback<Target>,
+  Callback extends LongPressCallback<Target, any> = LongPressCallback<Target>,
   Context = unknown
 >(callback: Callback, options?: LongPressOptions<Target>): CallableContextResult<LongPressResult<Target>, Context>;
 export function useLongPress<
   Target = Element,
-  Callback extends LongPressCallback<Target> = LongPressCallback<Target>,
+  Callback extends LongPressCallback<Target, any> = LongPressCallback<Target>,
   Context = unknown
 >(
   callback: Callback | null,


### PR DESCRIPTION
The context property is of type `unknown`. Setting a custom context type should be possible as such:
```ts
type MyType = { a: string, b: boolean };
const bind = useLongPress<Element, LongPressCallback<Element, MyType>, MyType>(
  (event, { context }) => { /* context should have type 'MyType' */ }
);
```
But this fails:
```
Type 'LongPressCallback<Element, { a: string, b: boolean }>' does not satisfy the constraint 'LongPressCallback<Element, unknown>'.
Type 'unknown' is not assignable to type '{ a: string, b: boolean }'.
```
By setting the `useLongPress` `Callback` type to include `any` without changing its default value, the context type is overwritable while keeping the default `unknown` when no type parameters are specified.